### PR TITLE
Remove nerenai.ga as it is no longer maintained

### DIFF
--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -19,7 +19,6 @@ const KUSO_DOMAINS = [
   "iidesuyo.com",
   "sounanokamoshiremasen.ga",
   "yasetai.dev",
-  "nerenai.ga",
   "ohayougozaima.su",
   "kuneku.net",
   "yoroshiku.onegai.shim.earth",


### PR DESCRIPTION
#23 で追加した nerenai.ga というドメインですが、ぼんやりと所有権がなくなってしまいました。取り戻せそうもないので、申し訳ないのですが、ドメインリストから削除します。